### PR TITLE
Update gcos-esoc2025-batches.md

### DIFF
--- a/cards/gcos-esoc2025-batches.md
+++ b/cards/gcos-esoc2025-batches.md
@@ -47,7 +47,7 @@ If you get stuck or have questions, please feel free to reach out to us on `info
 
 The deadline to complete all of these is April 9, 18:00 (UTC) for batch 1, or May 14, 18:00 (UTC) for batch 3.
 
-1. Fill in and submit the [ESoC application form](https://www.linkedin.com/posts/european-summer-of-code_european-summer-of-code-activity-7308135810648715264-RbpO)
+1. Fill in and submit the [ESoC application form](https://forms.office.com/e/ArWLD0DqVv)
 
 2. Fill in and submit the [Project application form](https://forms.office.com/e/GhGWQLdseU).
 


### PR DESCRIPTION
The link for the esoc application form pointed towards the linkedin page for esoc rather than the application form which I think might be confusing for someone applying , thought I'd point it out . Sorry if it was an intentional choice .